### PR TITLE
Fix bad style value being passed

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -182,10 +182,10 @@ export default class Collapsible extends Component {
     const { collapsed, enablePointerEvents } = this.props;
     const { height, contentHeight, measuring, measured } = this.state;
     const hasKnownHeight = !measuring && (measured || collapsed);
-    const style = hasKnownHeight && {
+    const style = hasKnownHeight ? {
       overflow: 'hidden',
       height: height,
-    };
+    } : {};
     const contentStyle = {};
     if (measuring) {
       contentStyle.position = 'absolute';


### PR DESCRIPTION
`false` isn't a valid value for the `style` prop, and it causes tests that touch this component to fail. This PR gives `style` a default value of `{}` if `hasKnownHeight` is not truthy